### PR TITLE
fix: add const values to schemas

### DIFF
--- a/lib/schemas/keyreg.transaction.nonparticipation.json
+++ b/lib/schemas/keyreg.transaction.nonparticipation.json
@@ -8,7 +8,12 @@
       "$ref": "http://algo-models.com/schemas/bytes32.json"
     },
     "type": {
-      "type": "string"
+      "type": "string",
+      "const": "keyreg"
+    },
+    "nonpart": {
+      "type": "boolean",
+      "const": true
     },
     "fee": {
       "type": "integer",
@@ -16,9 +21,6 @@
     },
     "snd": {
       "$ref": "http://algo-models.com/schemas/bytes32.json"
-    },
-    "nonpart": {
-      "type": "boolean"
     },
     "fv": {
       "type": "integer",
@@ -32,9 +34,9 @@
   "required": [
     "gh",
     "type",
+    "nonpart",
     "fee",
     "snd",
-    "nonpart",
     "fv",
     "lv",
     "note"

--- a/lib/schemas/keyreg.transaction.offline.json
+++ b/lib/schemas/keyreg.transaction.offline.json
@@ -1,0 +1,581 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://algo-models.com/schemas/keyreg.transaction.offline.json",
+  "title": "Key Registration Offline Transaction",
+  "type": "object",
+  "properties": {
+    "gh": {
+      "$ref": "http://algo-models.com/schemas/bytes32.json"
+    },
+    "type": {
+      "type": "string",
+      "const": "keyreg"
+    },
+    "nonpart": {
+      "type": "boolean",
+      "const": false
+    },
+    "fee": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "snd": {
+      "$ref": "http://algo-models.com/schemas/bytes32.json"
+    },
+    "fv": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "lv": {
+      "type": "integer",
+      "minimum": 0
+    }
+  },
+  "required": [
+    "gh",
+    "type",
+    "fee",
+    "snd",
+    "fv",
+    "lv"
+  ],
+  "not": {
+    "required": [
+      "votekey",
+      "selkey",
+      "sprfkey",
+      "votefst",
+      "votelst",
+      "votekd"
+
+    ]
+  },
+  "$defs": {
+    "bytes32": {
+      "$id": "http://algo-models.com/schemas/bytes32.json",
+      "type": "object",
+      "properties": {
+        "0": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "1": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "2": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "3": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "4": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "5": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "6": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "7": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "8": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "9": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "10": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "11": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "12": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "13": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "14": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "15": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "16": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "17": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "18": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "19": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "20": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "21": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "22": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "23": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "24": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "25": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "26": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "27": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "28": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "29": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "30": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "31": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        }
+      },
+      "required": [
+        "0",
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8",
+        "9",
+        "10",
+        "11",
+        "12",
+        "13",
+        "14",
+        "15",
+        "16",
+        "17",
+        "18",
+        "19",
+        "20",
+        "21",
+        "22",
+        "23",
+        "24",
+        "25",
+        "26",
+        "27",
+        "28",
+        "29",
+        "30",
+        "31"
+      ]
+    },
+    "bytes64": {
+      "$id": "http://algo-models.com/schemas/bytes64.json",
+      "type": "object",
+      "properties": {
+        "0": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "1": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "2": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "3": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "4": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "5": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "6": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "7": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "8": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "9": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "10": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "11": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "12": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "13": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "14": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "15": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "16": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "17": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "18": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "19": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "20": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "21": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "22": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "23": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "24": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "25": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "26": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "27": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "28": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "29": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "30": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "31": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "32": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "33": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "34": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "35": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "36": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "37": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "38": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "39": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "40": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "41": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "42": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "43": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "44": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "45": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "46": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "47": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "48": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "49": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "50": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "51": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "52": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "53": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "54": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "55": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "56": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "57": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "58": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "59": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "60": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "61": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "62": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "63": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        }
+      }
+    }
+  }
+}

--- a/lib/schemas/keyreg.transaction.online.json
+++ b/lib/schemas/keyreg.transaction.online.json
@@ -1,14 +1,19 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://algo-models.com/schemas/keyreg.transaction.json",
-  "title": "Key Registration Transaction",
+  "$id": "http://algo-models.com/schemas/keyreg.transaction.online.json",
+  "title": "Key Registration Online Transaction",
   "type": "object",
   "properties": {
     "gh": {
       "$ref": "http://algo-models.com/schemas/bytes32.json"
     },
     "type": {
-      "type": "string"
+      "type": "string",
+      "const": "keyreg"
+    },
+    "nonpart": {
+      "type": "boolean",
+      "const": false
     },
     "fee": {
       "type": "integer",

--- a/lib/schemas/pay.transaction.json
+++ b/lib/schemas/pay.transaction.json
@@ -11,7 +11,8 @@
       "$ref": "bytes32.json"
     },
     "type": {
-      "type": "string"
+      "type": "string",
+      "const": "pay"
     },
     "fee": {
       "type": "integer"


### PR DESCRIPTION
# Overview
- Split Key registration schema to online and offline schemas
- Make transactions type a constant in keyreg and pay transactions
- Make `nonpart` a const in keyreg schema