### PR TITLE
fix: add const values to schemas

### DIFF
--- a/lib/schemas/keyreg.transaction.json
+++ b/lib/schemas/keyreg.transaction.json
@@ -8,7 +8,8 @@
       "$ref": "http://algo-models.com/schemas/bytes32.json"
     },
     "type": {
-      "type": "string"
+      "type": "string",
+      "const": "keyreg"
     },
     "fee": {
       "type": "integer",

--- a/lib/schemas/keyreg.transaction.nonparticipation.json
+++ b/lib/schemas/keyreg.transaction.nonparticipation.json
@@ -8,7 +8,8 @@
       "$ref": "http://algo-models.com/schemas/bytes32.json"
     },
     "type": {
-      "type": "string"
+      "type": "string",
+      "const": "keyreg"
     },
     "fee": {
       "type": "integer",

--- a/lib/schemas/pay.transaction.json
+++ b/lib/schemas/pay.transaction.json
@@ -11,7 +11,8 @@
       "$ref": "bytes32.json"
     },
     "type": {
-      "type": "string"
+      "type": "string",
+      "const": "pay"
     },
     "fee": {
       "type": "integer"


### PR DESCRIPTION
# Overview
- Make transactions type a constant in keyreg and pay transactions
