### PR TITLE
ci: coverage reporters and provenance

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,3 +26,8 @@ jobs:
       -
         name: Unit Tests with Coverage
         run: npm run test:cov
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,9 @@ jobs:
         with:
           node-version: '20.x'
           cache: 'npm'
-      - run: npm install
+      - run: npm clean-install
+      - name: Verify the integrity of provenance
+        run: npm audit signatures
       - run: npm run build
       - run: npm run release
         env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@algorandfoundation/algo-models",
-  "version": "0.0.6",
+  "version": "1.0.0-canary.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@algorandfoundation/algo-models",
-      "version": "0.0.6",
+      "version": "1.0.0-canary.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
   },
   "author": "",
   "license": "AGPL-3.0-or-later",
+  "publishConfig": {
+    "provenance": true
+  },
   "devDependencies": {
     "@commitlint/cli": "^17.8.0",
     "@commitlint/config-conventional": "^17.8.0",


### PR DESCRIPTION
# Overview

- adds provenance (verified packages) to npm package.
- verifies dependency signatures
- reports code coverage to `codecov`

Details on provenance can be found in [the announcement](https://github.blog/security/supply-chain-security/introducing-npm-package-provenance/) from npm